### PR TITLE
Add space between names on signup and change link to profile into button

### DIFF
--- a/src/components/Form/SignUpForm.tsx
+++ b/src/components/Form/SignUpForm.tsx
@@ -14,7 +14,7 @@ const SignUpForm: React.FC<SignUpFormProps> = () => {
   });
 
   useEffect(() => {
-    setFormData((prev) => ({ ...prev, Name: `${first}` + `${last}` }));
+    setFormData((prev) => ({ ...prev, Name: `${first} ` + `${last}` }));
   }, [first, last]);
 
   const handleSignup = async (e: React.FormEvent<HTMLFormElement>) => {

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -2,6 +2,7 @@ import { FaRegCircleUser } from "react-icons/fa6";
 // import { useEffect } from 'react';
 import { useAuth } from "../context/AuthContext";
 import { Link } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 //if authenticated -> view profile icon + logout
 //if not authenticated -> login + signup
 // useEffect(() => {
@@ -12,6 +13,7 @@ import { Link } from "react-router-dom";
 // })
 const Navbar = () => {
   const { isLoggedIn, logout } = useAuth();
+  const navigate = useNavigate();
 
   return (
     <div className="sticky top-0 fixed mt-6">
@@ -32,9 +34,10 @@ const Navbar = () => {
                   <a>Logout</a>
                 </button>
                 <div className="flex justify-center items-center pr-7 pl-6 hover:scale-110">
-                  <Link to="/profile">
+                  <button onClick={() => navigate("/profile")}>
                     <FaRegCircleUser className="text-4xl text-white" />
-                  </Link>
+                  </button>
+
                 </div>
               </>
             ) : (


### PR DESCRIPTION
1. Put space between first name and last name on Sign Up Form
2. Converted link to profile page into a button that navigates to profile page on click